### PR TITLE
Add binding & condition method aliases back in

### DIFF
--- a/lib/rule_helper.rb
+++ b/lib/rule_helper.rb
@@ -35,10 +35,14 @@ module Ruleby
     def b(variable_name)
       Ruleby::Ferrari::BindingBuilder.new(variable_name)
     end
+
+    alias_method :binding, :b
     
     def c(&block)
       return lambda(&block)
     end
+
+    alias_method :condition, :c
 
     def OR(*args)
       Ruleby::Ferrari::OrBuilder.new args


### PR DESCRIPTION
I've added the binding & condition method aliases back in. These were removed in August 2010 by Matt Smith saying they were "causing conflicts", however just having b and c makes the rules very hard to read for someone unfamiliar with the syntax. 

I've run the project I'm working on now with this change, and the test suite, and have encountered no issues.