### PR TITLE
Add license to gemspec

### DIFF
--- a/ruleby.gemspec
+++ b/ruleby.gemspec
@@ -14,4 +14,5 @@ the forward chaining Rete algorithm. Ruleby provides an internal Domain Specific
   s.require_paths = [%q{lib}]
   s.rubyforge_project = %q{ruleby}
   s.summary = %q{Rete based Ruby Rule Engine}
+  s.license = %q{Ruby}
 end


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.