### PR TITLE
Sorting on macOS and Ubuntu acts differently

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,14 @@ of IF-THEN statements known as production rules. These rules are matched to obje
 the forward chaining Rete algorithm. Ruleby provides an internal Domain Specific Language 
 (DSL) for building the productions that make up a Ruleby program.
 
+Test
+-------------
+
+Run test with
+```
+ruby test/test.rb
+```
+
 Version 
 -------
 0.9.b7

--- a/examples/fibonacci_example1.rb
+++ b/examples/fibonacci_example1.rb
@@ -11,7 +11,7 @@
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), '../lib/')
 require 'ruleby'
-require 'fibonacci_rulebook'
+require_relative 'fibonacci_rulebook'
 class Fibonacci
   def initialize(sequence,value=-1)
     @sequence = sequence

--- a/examples/fibonacci_example2.rb
+++ b/examples/fibonacci_example2.rb
@@ -11,7 +11,7 @@
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), '../lib/')
 require 'ruleby'
-require 'fibonacci_rulebook'
+require_relative 'fibonacci_rulebook'
 class Fibonacci
   def initialize(sequence,value=-1)
     @sequence = sequence

--- a/examples/ticket.rb
+++ b/examples/ticket.rb
@@ -46,7 +46,7 @@ class TroubleTicketRulebook < Rulebook
     # the same rule set.
     rule :New_Ticket, {:priority => 10}, # :duration => 10},
       [Customer, :c],
-      [Ticket, :ticket, {m.customer => :c}, m.status == :New] do |vars|
+      [Ticket, :ticket, {m.customer => :ticket_customer}, m.customer == b(:c), m.status == :New] do |vars|
         puts 'New : ' + vars[:ticket].to_s
     end
     
@@ -75,13 +75,13 @@ class TroubleTicketRulebook < Rulebook
     
     rule :Escalate,
       [Customer, :c],
-      [Ticket, :ticket, {m.customer => :c}, m.status == :Escalate] do |vars|
+      [Ticket, :ticket, {m.customer => :ticket_customer}, m.customer == b(:c), m.status == :Escalate] do |vars|
         puts 'Email : ' + vars[:ticket].to_s    
     end
     
     rule :Done,
       [Customer, :c],
-      [Ticket, :ticket, {m.customer => :c}, m.status == :Done] do |vars|
+      [Ticket, :ticket, {m.customer => :ticket_cutomer}, m.customer == b(:c), m.status == :Done] do |vars|
         puts 'Done : ' + vars[:ticket].to_s
     end
   end

--- a/lib/core/engine.rb
+++ b/lib/core/engine.rb
@@ -139,7 +139,10 @@ module Ruleby
   # properties of the activation.
   class RulebyConflictResolver   
     def resolve(agenda) 
-      return agenda.sort
+      # Sorting objects with equal properties will not preserve original sort so
+      # we need to use index since someone could rely on the order of rules
+      # https://stackoverflow.com/a/64793425/287166
+      agenda.sort_by.with_index { |a, i| [a, i] }
     end    
   end
   

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -8,13 +8,13 @@
 #
 # * Authors: John Mettraux
 #
-require 'common'
-require 'duck_type'
-require 'self_reference'
-require 'regex'
-require 'gets'
-require 'assert_facts'
-require 'not_patterns'
-require 'or_patterns'
-require 'join_nodes'
-require 'nil'
+require_relative 'common'
+require_relative 'duck_type'
+require_relative 'self_reference'
+require_relative 'regex'
+require_relative 'gets'
+require_relative 'assert_facts'
+require_relative 'not_patterns'
+require_relative 'or_patterns'
+require_relative 'join_nodes'
+require_relative 'nil'


### PR DESCRIPTION
I had a problem to run same code on different machines since the sort was giving different results for the array of rules with same properties.
Now we use `sort_by.with_index` so the order is preserved